### PR TITLE
Update dotnetBuildTest.yml

### DIFF
--- a/.github/workflows/dotnetBuildTest.yml
+++ b/.github/workflows/dotnetBuildTest.yml
@@ -47,8 +47,9 @@ jobs:
   # Define a deploy to development environment job
   deployDev:
     name: Deploy to Development
-    # Job runs only if the event is a pull request
+    # Job runs only if the event is a pull request && github.event.ref == 'refs/heads/main'
     if: github.event_name == 'pull_request'
+    
     # The job needs the build job to pass first
     needs: [build]
     runs-on: ubuntu-latest
@@ -63,9 +64,7 @@ jobs:
   
   # Our deployment to staging environment
   deployStaging:
-    name: Deploy to Staging
-    # deploy to staging only if we are committing to main
-    if: github.event.ref == 'refs/heads/main'
+    name: Deploy to Staging    
     needs: [deployDev]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
combining conditions at development level.
If PR to main and main is referenced in event.
Probably no need to check if the even references main - in the end, PR is going to main, therefore main should always be referenced in this instance, one might think